### PR TITLE
Update requirements.txt - lacking dependency for langchain

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -136,6 +136,7 @@ langchain-core
 langchain-openai
 langchain-text-splitters
 langsmith==0.1.98
+langchain-together
 llama-index==0.10.38
 llama-index-agent-openai==0.2.5
 llama-index-cli==0.1.12


### PR DESCRIPTION
currently, 

if I ran pip install -r requirements.txt, I failed to execute the "build_knowledge_graph.py" script when all dependencies were installed. 

It said that "ModuleNotFoundError: No module named 'langchain_together'"

So, it requires to add one more dependency for langchain.