### PR TITLE
Fix Python 3.11 f-string syntax for hyperparameter answer files

### DIFF
--- a/query_llm.py
+++ b/query_llm.py
@@ -144,7 +144,8 @@ if __name__ == '__main__':
         if 'hyperparams' in config.query:
             answer_file = os.path.basename(config.query.answers_file)
             answer_fname, answer_ftype = answer_file.split('.')
-            config.query.answers_file = f'{answer_dir}/{answer_fname}_{'_'.join([f'{k}{v}' for k, v in config.query.hyperparams.items()])}.{answer_ftype}' 
+            hyperparams_str = '_'.join(f'{k}{v}' for k, v in config.query.hyperparams.items())
+            config.query.answers_file = f'{answer_dir}/{answer_fname}_{hyperparams_str}.{answer_ftype}'
         if os.path.exists(config.query.answers_file) and not config.rewrite:
             exit(f"Answers file {config.query.answers_file} already exists.")
 

--- a/test_answers.py
+++ b/test_answers.py
@@ -10,7 +10,8 @@ if __name__ == '__main__':
     if 'hyperparams' in config.query:
         answer_file = os.path.basename(config.query.answers_file)
         answer_fname, answer_ftype = answer_file.split('.')
-        config.query.answers_file = f'{answer_dir}/{answer_fname}_{'_'.join([f'{k}{v}' for k, v in config.query.hyperparams.items()])}.{answer_ftype}' 
+        hyperparams_str = '_'.join(f'{k}{v}' for k, v in config.query.hyperparams.items())
+        config.query.answers_file = f'{answer_dir}/{answer_fname}_{hyperparams_str}.{answer_ftype}'
         config.evaluator.eval_file = config.query.answers_file
 
     if 'GuidelineFollow' in config.evaluator.metrics:


### PR DESCRIPTION
## Summary

- Moves the hyperparameter suffix construction out of the outer f-string in `query_llm.py`.
- Applies the same Python 3.11-compatible fix in `test_answers.py`.

This addresses the `SyntaxError: f-string: expecting '}'` reported in #21 while keeping the generated answer-file naming behavior unchanged.

## Validation

- `git diff --check`
- `py -3.11 -m py_compile query_llm.py test_answers.py`
- `py -3.14 -m py_compile query_llm.py test_answers.py`